### PR TITLE
Map Stockfish difficulties to skill levels

### DIFF
--- a/backend/src/chess/StockfishGame.ts
+++ b/backend/src/chess/StockfishGame.ts
@@ -14,10 +14,17 @@ import { v4 as uuidv4 } from "uuid";
 export type Difficulty = "easy" | "medium" | "hard" | "expert";
 
 const DIFFICULTY_ELO: Record<Difficulty, number> = {
-  easy: 800,
-  medium: 1400,
-  hard: 2000,
+  easy: 1320,
+  medium: 1600,
+  hard: 2200,
   expert: 3000,
+};
+
+const DIFFICULTY_SKILL_LEVEL: Record<Difficulty, number> = {
+  easy: 0,
+  medium: 7,
+  hard: 14,
+  expert: 20,
 };
 
 const DIFFICULTY_DEPTH: Record<Difficulty, number> = {
@@ -115,6 +122,7 @@ export class StockfishGame {
         this.stockfish.stdout.setEncoding("utf8");
 
         this.stockfish.stdin.write("uci\n");
+        this.stockfish.stdin.write(`setoption name Skill Level value ${DIFFICULTY_SKILL_LEVEL[this.difficulty]}\n`);
         this.stockfish.stdin.write(`setoption name UCI_LimitStrength value true\n`);
         this.stockfish.stdin.write(`setoption name UCI_Elo value ${DIFFICULTY_ELO[this.difficulty]}\n`);
         this.stockfish.stdin.write("isready\n");


### PR DESCRIPTION
Summary:
- Use Stockfish-supported ELO values for each difficulty.
- Add explicit Stockfish skill levels so easy, medium, hard, and expert map to distinct engine strengths.

Test plan:
- `git diff --check`
- Attempted backend `npm ci --ignore-scripts --no-audit`, but npm is unavailable in this Codex shell.

Closes #59