### PR TITLE
Fix ERR_MODULE_NOT_FOUND: add .js extensions to relative imports

### DIFF
--- a/src/chess/Game.ts
+++ b/src/chess/Game.ts
@@ -9,9 +9,9 @@ import {
   OPPONENT_DISCONNECTED,
   OPPONENT_RECONNECTED,
   RECONNECT_TIMEOUT_SECONDS,
-} from "./messages";
-import { redisService, PersistedGame } from "./RedisService";
-import { gameHistoryService } from "../services/gameHistoryService";
+} from "./messages.js";
+import { redisService, PersistedGame } from "./RedisService.js";
+import { gameHistoryService } from "../services/gameHistoryService.js";
 import { v4 as uuidv4 } from "uuid";
 
 /**

--- a/src/chess/GameManager.ts
+++ b/src/chess/GameManager.ts
@@ -1,8 +1,8 @@
 import { WebSocket } from "ws";
-import { INIT_GAME, MOVE, GET_VALID_MOVES, RECONNECT, PLAY_VS_COMPUTER, GAME_STATE } from "./messages";
-import { Game } from "./Game";
-import { StockfishGame, Difficulty } from "./StockfishGame";
-import { redisService, GameCommandEnvelope, ToPlayerEnvelope } from "./RedisService";
+import { INIT_GAME, MOVE, GET_VALID_MOVES, RECONNECT, PLAY_VS_COMPUTER, GAME_STATE } from "./messages.js";
+import { Game } from "./Game.js";
+import { StockfishGame, Difficulty } from "./StockfishGame.js";
+import { redisService, GameCommandEnvelope, ToPlayerEnvelope } from "./RedisService.js";
 import { v4 as uuidv4 } from "uuid";
 
 interface PendingPlayer {

--- a/src/chess/StockfishGame.ts
+++ b/src/chess/StockfishGame.ts
@@ -12,8 +12,8 @@ import {
   MOVE,
   VALID_MOVES,
   TIME_UPDATE,
-} from "./messages";
-import { gameHistoryService } from "../services/gameHistoryService";
+} from "./messages.js";
+import { gameHistoryService } from "../services/gameHistoryService.js";
 import { v4 as uuidv4 } from "uuid";
 
 export type Difficulty = "easy" | "medium" | "hard" | "expert";

--- a/src/controllers/aiController.ts
+++ b/src/controllers/aiController.ts
@@ -1,6 +1,6 @@
 import { Response } from "express";
-import { AuthenticatedRequest } from "../utils/types";
-import { gameHistoryService } from "../services/gameHistoryService";
+import { AuthenticatedRequest } from "../utils/types.js";
+import { gameHistoryService } from "../services/gameHistoryService.js";
 
 // In-memory cache for AI analysis (keyed by gameId)
 const aiAnalysisCache = new Map<string, string>();

--- a/src/controllers/analysisController.ts
+++ b/src/controllers/analysisController.ts
@@ -1,7 +1,7 @@
 import { Response } from "express";
-import { AuthenticatedRequest } from "../utils/types";
-import { gameHistoryService } from "../services/gameHistoryService";
-import { analyzeGame } from "../services/analysisService";
+import { AuthenticatedRequest } from "../utils/types.js";
+import { gameHistoryService } from "../services/gameHistoryService.js";
+import { analyzeGame } from "../services/analysisService.js";
 
 // In-memory cache so we don't re-analyze the same game twice
 const analysisCache = new Map<string, object>();

--- a/src/controllers/authController.ts
+++ b/src/controllers/authController.ts
@@ -1,6 +1,6 @@
-import AuthService from "../services/authServices";
+import AuthService from "../services/authServices.js";
 import { Request, Response } from "express";
-import { AuthenticatedRequest } from "../utils/types";
+import { AuthenticatedRequest } from "../utils/types.js";
 import jwt from "jsonwebtoken";
 
 class AuthController {

--- a/src/controllers/gameController.ts
+++ b/src/controllers/gameController.ts
@@ -1,6 +1,6 @@
 import { Response } from "express";
-import { AuthenticatedRequest } from "../utils/types";
-import { gameHistoryService } from "../services/gameHistoryService";
+import { AuthenticatedRequest } from "../utils/types.js";
+import { gameHistoryService } from "../services/gameHistoryService.js";
 
 class GameController {
   /**

--- a/src/controllers/leaderboardController.ts
+++ b/src/controllers/leaderboardController.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from "express";
-import RatingService from "../services/ratingService";
+import RatingService from "../services/ratingService.js";
 
 class LeaderboardController {
   /** GET /api/leaderboard?type=game|puzzle — public, no auth needed */

--- a/src/controllers/puzzleController.ts
+++ b/src/controllers/puzzleController.ts
@@ -1,6 +1,6 @@
 import { Response } from "express";
-import { AuthenticatedRequest } from "../utils/types";
-import PuzzleService from "../services/puzzleService";
+import { AuthenticatedRequest } from "../utils/types.js";
+import PuzzleService from "../services/puzzleService.js";
 
 class PuzzleController {
   /** GET /api/puzzles/next — rating-matched next puzzle for the logged-in user */

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,10 +8,10 @@ import { parse, fileURLToPath } from "url";
 import path from "path";
 import fs from "fs";
 
-import AuthRouter from "./routes/authRoutes";
-import { GameManager } from "./chess/GameManager";
-import { verifyToken } from "./utils/jwt";
-import { isFrontendRoute } from "./frontendRegistry";
+import AuthRouter from "./routes/authRoutes.js";
+import { GameManager } from "./chess/GameManager.js";
+import { verifyToken } from "./utils/jwt.js";
+import { isFrontendRoute } from "./frontendRegistry.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);

--- a/src/middlewares/authMiddleware.ts
+++ b/src/middlewares/authMiddleware.ts
@@ -1,6 +1,6 @@
 import { Response, NextFunction } from "express";
-import { verifyToken } from "../utils/jwt";
-import { AuthenticatedRequest } from "../utils/types";
+import { verifyToken } from "../utils/jwt.js";
+import { AuthenticatedRequest } from "../utils/types.js";
 
 class AuthMiddleware {
   static authenticate = (

--- a/src/routes/authRoutes.ts
+++ b/src/routes/authRoutes.ts
@@ -1,12 +1,12 @@
 import { Router } from "express";
-import AuthController from "../controllers/authController";
-import AuthMiddleware from "../middlewares/authMiddleware";
-import { authRateLimiter } from "../middlewares/rateLimiters";
-import GameController from "../controllers/gameController";
-import AnalysisController from "../controllers/analysisController";
-import AIController from "../controllers/aiController";
-import PuzzleController from "../controllers/puzzleController";
-import LeaderboardController from "../controllers/leaderboardController";
+import AuthController from "../controllers/authController.js";
+import AuthMiddleware from "../middlewares/authMiddleware.js";
+import { authRateLimiter } from "../middlewares/rateLimiters.js";
+import GameController from "../controllers/gameController.js";
+import AnalysisController from "../controllers/analysisController.js";
+import AIController from "../controllers/aiController.js";
+import PuzzleController from "../controllers/puzzleController.js";
+import LeaderboardController from "../controllers/leaderboardController.js";
 
 const router = Router();
 

--- a/src/services/authServices.ts
+++ b/src/services/authServices.ts
@@ -1,4 +1,4 @@
-import { prisma } from '../lib/prisma';
+import { prisma } from '../lib/prisma.js';
 import bcrypt from 'bcryptjs';
 import jwt from 'jsonwebtoken';
 const JWT_SECRET = process.env.JWT_SECRET!;

--- a/src/services/gameHistoryService.ts
+++ b/src/services/gameHistoryService.ts
@@ -1,5 +1,5 @@
-import { prisma } from '../lib/prisma'
-import RatingService from './ratingService';
+import { prisma } from '../lib/prisma.js';
+import RatingService from './ratingService.js';
 
 interface SaveGameResultParams {
   gameId: string;

--- a/src/services/puzzleService.ts
+++ b/src/services/puzzleService.ts
@@ -1,6 +1,6 @@
-import { prisma } from "../lib/prisma";
+import { prisma } from "../lib/prisma.js";
 import { Chess } from "chess.js";
-import { updateRating, GlickoRating } from "./glicko2";
+import { updateRating, GlickoRating } from "./glicko2.js";
 
 /**
  * Puzzle format (lichess-style single line):

--- a/src/services/ratingService.ts
+++ b/src/services/ratingService.ts
@@ -1,5 +1,5 @@
-import { prisma } from "../lib/prisma";
-import { updatePair, GlickoRating } from "./glicko2";
+import { prisma } from "../lib/prisma.js";
+import { updatePair, GlickoRating } from "./glicko2.js";
 
 interface RatedGameResult {
   gameId: string;


### PR DESCRIPTION
Fixes the production crash: Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/opt/render/project/src/dist/routes/authRoutes' imported from /opt/render/project/src/dist/index.js

Root cause: package.json sets "type": "module" and tsconfig.json uses "module": "ESNext", so tsc does not rewrite relative import paths. The compiled files under dist/ keep extension-less imports like "./routes/authRoutes", which Node's native ESM loader cannot resolve at runtime (unlike ts-node/tsx used in dev, which are more lenient).

Fix: added explicit .js extensions to every relative import across the 16 affected source files (index.ts, chess/Game.ts, chess/GameManager.ts, chess/StockfishGame.ts, all controllers, both middlewares files, routes/authRoutes.ts, and all affected services). No behavior changes, only import path strings.

Note: Render's Branch setting for this service is currently "main", so this PR targets main since that's what's actually deployed.